### PR TITLE
Remove unecessary negative check in compute_twist_wrt_to_world in shared.py

### DIFF
--- a/hexapod/ik_solver/shared.py
+++ b/hexapod/ik_solver/shared.py
@@ -2,15 +2,16 @@ from hexapod.points import is_counter_clockwise, angle_between, rotz
 
 
 def update_hexapod_points(hexapod, leg_id, points):
-    points[0].name = hexapod.legs[leg_id].p0.name
-    points[1].name = hexapod.legs[leg_id].p1.name
-    points[2].name = hexapod.legs[leg_id].p2.name
-    points[3].name = hexapod.legs[leg_id].p3.name
+    leg = hexapod.legs[leg_id]
+    points[0].name = leg.p0.name
+    points[1].name = leg.p1.name
+    points[2].name = leg.p2.name
+    points[3].name = leg.p3.name
 
-    hexapod.legs[leg_id].p0 = points[0]
-    hexapod.legs[leg_id].p1 = points[1]
-    hexapod.legs[leg_id].p2 = points[2]
-    hexapod.legs[leg_id].p3 = points[3]
+    leg.p0 = points[0]
+    leg.p1 = points[1]
+    leg.p2 = points[2]
+    leg.p3 = points[3]
 
 
 def find_twist_frame(hexapod, unit_coxia_vector):
@@ -26,8 +27,5 @@ def find_twist_frame(hexapod, unit_coxia_vector):
 def compute_twist_wrt_to_world(alpha, coxia_axis):
     alpha = (alpha - coxia_axis) % 360
     if alpha > 180:
-        alpha = alpha - 360
-    elif alpha < -180:
-        alpha = 360 + alpha
-
+        return alpha - 360
     return alpha


### PR DESCRIPTION
`alpha = (alpha - coxia_axis) % 360` sets alpha to a value in [0, 360) (% returns a value with the sign of the denominator), so the `if alpha < -180` statement will never be hit - removing this gives a 10% speedup.

Additionally, fetching `hexapod.legs[leg_id]` once is an easy optimization and prevents copy/paste errors (and also gives a 10% speedup).
