### PR TITLE
Optimizations in models.py, minor code quality improvements

### DIFF
--- a/hexapod/models.py
+++ b/hexapod/models.py
@@ -315,36 +315,36 @@ def find_twist_frame(old_ground_contacts, new_ground_contacts):
     return twist_frame
 
 
-def might_print_hexapod(hexapod, poses):	
-    if not PRINT_MODEL_ON_UPDATE:	
-        return	
+def might_print_hexapod(hexapod, poses):
+    if not PRINT_MODEL_ON_UPDATE:
+        return
 
-    print("█████████████████████████████")	
-    print("█ start: Hexapod Model      █")	
-    print("█████████████████████████████")	
+    print("█████████████████████████████")
+    print("█ start: Hexapod Model      █")
+    print("█████████████████████████████")
 
-    print("............")	
-    print("...Dimensions")	
-    print("............")	
-    print(json.dumps(hexapod.dimensions, indent=4))	
+    print("............")
+    print("...Dimensions")
+    print("............")
+    print(json.dumps(hexapod.dimensions, indent=4))
 
-    print("............")	
-    print("...Vertices")	
-    print("............")	
-    pprint(hexapod.body.all_points)	
+    print("............")
+    print("...Vertices")
+    print("............")
+    pprint(hexapod.body.all_points)
 
-    print("............")	
-    print("...Legs")	
-    print("............")	
-    for i, leg in enumerate(hexapod.legs):	
-        print(f"\nleg{i}_points = ")	
-        pprint(leg.all_points)	
+    print("............")
+    print("...Legs")
+    print("............")
+    for i, leg in enumerate(hexapod.legs):
+        print(f"\nleg{i}_points = ")
+        pprint(leg.all_points)
 
-    print("............")	
-    print("...Poses")	
-    print("............")	
-    print(json.dumps(poses, indent=4))	
+    print("............")
+    print("...Poses")
+    print("............")
+    print(json.dumps(poses, indent=4))
 
-    print("█████████████████████████████")	
-    print("█ end: Hexapod Model        █")	
-    print("█████████████████████████████")	
+    print("█████████████████████████████")
+    print("█ end: Hexapod Model        █")
+    print("█████████████████████████████")

--- a/hexapod/models.py
+++ b/hexapod/models.py
@@ -313,3 +313,38 @@ def find_twist_frame(old_ground_contacts, new_ground_contacts):
     # They should be at the same point after movement
     # I can't think of a case that contradicts this as of this moment
     return twist_frame
+
+
+def might_print_hexapod(hexapod, poses):	
+    if not PRINT_MODEL_ON_UPDATE:	
+        return	
+
+    print("█████████████████████████████")	
+    print("█ start: Hexapod Model      █")	
+    print("█████████████████████████████")	
+
+    print("............")	
+    print("...Dimensions")	
+    print("............")	
+    print(json.dumps(hexapod.dimensions, indent=4))	
+
+    print("............")	
+    print("...Vertices")	
+    print("............")	
+    pprint(hexapod.body.all_points)	
+
+    print("............")	
+    print("...Legs")	
+    print("............")	
+    for i, leg in enumerate(hexapod.legs):	
+        print(f"\nleg{i}_points = ")	
+        pprint(leg.all_points)	
+
+    print("............")	
+    print("...Poses")	
+    print("............")	
+    print(json.dumps(poses, indent=4))	
+
+    print("█████████████████████████████")	
+    print("█ end: Hexapod Model        █")	
+    print("█████████████████████████████")	


### PR DESCRIPTION
Relative imports can lead to problems with shuffling files - doing a package-relative import is usually a safer bet (eg. hexapod.linkage vs .linkage).

This also switches operations from numpy to math to speed operations up for singlular values.

Using tuples is also a good idea to enforce immutability - (eg. you would not want COXIA_AXES or VERTEX_NAMES to change)

For dictionaries, iterating over keys does not need a .keys() call (eg. `for x in dict.keys()`), since this is equivalent to `for x in dict:`. Additionally, using values allows accessing the dictionary values, which avoids iterating over the keys and fetching the values (alternatively, .items() returns both keys and values, but if you're dropping the key, you can use .values() instead).

Some other potential issues I noticed in the code:
`get_hip_angle` seems like it could cause bugs - we catch a key error on both [leg_id] and ["coxia"], which seems like it could mask the fact that "coxia" is missing, where we might actually want to raise an error, since this is a malformed leg.
Raising `Exception` is generally a bad idea, since catching this requires catching `Exception`, which means you catch every possible exception (and may miss valid exceptions which are caused by other problems). Subclassing Exceptions into HexapodError (and possibly further, possibly into InstabilityError or the like) would probably help in this case.

(Also - I'm totally down to be added as a contributor)