### PR TITLE
Fix all_points not being updated, change __repr__ to __str__

### DIFF
--- a/hexapod/ik_solver/shared.py
+++ b/hexapod/ik_solver/shared.py
@@ -3,9 +3,9 @@ from hexapod.points import is_counter_clockwise, angle_between, rotz
 
 def update_hexapod_points(hexapod, leg_id, points):
     leg = hexapod.legs[leg_id]
-    for leg_point, new_point in zip(leg.all_points, points):
-        new_point.name = leg_point.name
-        leg_point = new_point
+    for point, leg_point in zip(points, leg.all_points):
+        point.name = leg_point.name
+    leg.all_points = points
 
 
 def find_twist_frame(hexapod, unit_coxia_vector):

--- a/hexapod/linkage.py
+++ b/hexapod/linkage.py
@@ -159,7 +159,6 @@ class Linkage:
 
     def compute_ground_contact(self):
         # ❗IMPORTANT: Verify if this assumption is correct
-        # Which has the most negative z? p0, p1, p2, or p3?
         ground_contact = self.p3
         for point in reversed(self.all_points):
             if point.z < ground_contact.z:

--- a/hexapod/linkage.py
+++ b/hexapod/linkage.py
@@ -59,7 +59,7 @@
 
 import numpy as np
 from copy import deepcopy
-from .points import (
+from hexapod.points import (
     Point,
     frame_yrotate_xtranslate,
     frame_zrotate_xytranslate,
@@ -68,7 +68,8 @@ from .points import (
 
 class Linkage:
     POINT_NAMES = ["coxia", "femur", "tibia"]
-    __slots__ = [
+
+    __slots__ = (
         "a",
         "b",
         "c",
@@ -81,11 +82,7 @@ class Linkage:
         "id",
         "all_points",
         "ground_contact_point",
-        "p0",
-        "p1",
-        "p2",
-        "p3",
-    ]
+    )
 
     def __init__(
         self,
@@ -147,13 +144,13 @@ class Linkage:
         p3 = p0.get_point_wrt(frame_03)
 
         # find points wrt to center of gravity
-        self.p0 = deepcopy(self.new_origin)
-        self.p0.name += "-body-contact"
-        self.p1 = p1.get_point_wrt(new_frame, name=self.name + "-coxia")
-        self.p2 = p2.get_point_wrt(new_frame, name=self.name + "-femur")
-        self.p3 = p3.get_point_wrt(new_frame, name=self.name + "-tibia")
+        p0 = deepcopy(self.new_origin)
+        p0.name += "-body-contact"
+        p1 = p1.get_point_wrt(new_frame, name=self.name + "-coxia")
+        p2 = p2.get_point_wrt(new_frame, name=self.name + "-femur")
+        p3 = p3.get_point_wrt(new_frame, name=self.name + "-tibia")
 
-        self.all_points = [self.p0, self.p1, self.p2, self.p3]
+        self.all_points = [p0, p1, p2, p3]
         self.ground_contact_point = self.compute_ground_contact()
 
     def update_leg_wrt(self, frame, height):
@@ -162,6 +159,7 @@ class Linkage:
 
     def compute_ground_contact(self):
         # ❗IMPORTANT: Verify if this assumption is correct
+        # Which has the most negative z? p0, p1, p2, or p3?
         ground_contact = self.p3
         for point in reversed(self.all_points):
             if point.z < ground_contact.z:
@@ -169,8 +167,8 @@ class Linkage:
 
         return ground_contact
 
-    def __repr__(self):
-        leg_string = make_linkage_repr(self)
+    def __str__(self):
+        leg_string = f"{self!r}\n"
         leg_string += f"Points of {self.name} leg:\n"
 
         for point in self.all_points:
@@ -179,24 +177,34 @@ class Linkage:
         leg_string += f"  ground contact: {self.ground_contact()}\n"
         return leg_string
 
+    def __repr__(self):
+        return f"""Linkage(
+  a={self.a},
+  b={self.b},
+  c={self.c},
+  alpha={self.alpha},
+  beta={self.beta},
+  gamma={self.gamma},
+  new_axis={self.coxia_axis},
+  id_number={self.id},
+  name='{self.name}',
+  new_origin={self.new_origin},
+)"""
 
-def make_linkage_repr(leg):
-    return f"""Linkage(
-  a={leg.a},
-  b={leg.b},
-  c={leg.c},
-  alpha={leg.alpha},
-  beta={leg.beta},
-  gamma={leg.gamma},
-  new_axis={leg.coxia_axis},
-  id_number={leg.id},
-  name='{leg.name}',
-  new_origin={leg.new_origin},
-)
+    def __getattr__(self, item):
+        """Return self.item (if p0, p1, p2, or p3, returns item from all_points.)"""
+        attr_map = {"p0": 0, "p1": 1, "p2": 2, "p3": 3}
+        if item in attr_map:
+            return self.all_points[attr_map[item]]
+        return super().__getattribute__(item)
 
-"""
-
-
+    def __setattr__(self, key, value):
+        """Set self.key (if p0, p1, p2, or p3, sets key in all_points."""
+        attr_map = {"p0": 0, "p1": 1, "p2": 2, "p3": 3}
+        if key in attr_map:
+            self.all_points[attr_map[key]] = value
+        else:
+            super().__setattr__(key, value)
 #
 #          /*
 #         //\\

--- a/tests/test_ik.py
+++ b/tests/test_ik.py
@@ -42,10 +42,12 @@ def test_points_ik2():
 
 
 def test_shared_set_points():
-    points = [Point(1, 2, 3, "a"),
-    Point(1, 2, 3, "b"),
-    Point(1, 2, 3, "c"),
-    Point(1, 2, 3, "d")]
+    points = [
+        Point(1, 2, 3, "a"),
+        Point(1, 2, 3, "b"),
+        Point(1, 2, 3, "c"),
+        Point(1, 2, 3, "d")
+    ]
 
     vh = VirtualHexapod(BASE_DIMENSIONS)
     update_hexapod_points(vh, 1, points)

--- a/tests/test_ik.py
+++ b/tests/test_ik.py
@@ -1,7 +1,9 @@
 from copy import deepcopy
+from hexapod.const import BASE_DIMENSIONS
 from hexapod.models import VirtualHexapod
-import hexapod.ik_solver.ik_solver2 as ik_solver2
-import hexapod.ik_solver.ik_solver as ik_solver
+from hexapod.points import Point
+from hexapod.ik_solver import ik_solver, ik_solver2
+from hexapod.ik_solver.shared import update_hexapod_points
 
 from tests.ik_cases import case1, case2
 from tests.helpers import assert_poses_equal, assert_two_hexapods_equal
@@ -37,3 +39,23 @@ def test_points_ik2():
         hexapod_k.update(case.correct_poses)
 
         assert_two_hexapods_equal(hexapod_ik, hexapod_k, case.description)
+
+
+def test_shared_set_points():
+    points = [Point(1, 2, 3, "a"),
+    Point(1, 2, 3, "b"),
+    Point(1, 2, 3, "c"),
+    Point(1, 2, 3, "d")]
+
+    vh = VirtualHexapod(BASE_DIMENSIONS)
+    update_hexapod_points(vh, 1, points)
+    for legpoint, point in zip(vh.legs[1].all_points, points):
+        assert legpoint == point
+
+
+def test_set_leg_point():
+    vh = VirtualHexapod(BASE_DIMENSIONS)
+    point = Point(1, 2, 3, "b")
+    vh.legs[0].p0 = Point(1, 2, 3, "b")
+    assert vh.legs[0].p0 == point
+    assert vh.legs[0].all_points[0] == point


### PR DESCRIPTION
This fixes Linkage.all_points not reflecting the fact that p0...p3 were changed, tidies up an import, and changes `__repr__` to `__str__` (since the expectation is that `__repr__` can be used to create a new instance of the same object, and `__str__` is a representative string).

This also adds tests to ensure that setting p0...p3 works correctly, and that all_points changes correspondingly.