### PR TITLE
Rename functions to better names, update comments

### DIFF
--- a/hexapod/ground_contact_solver.py
+++ b/hexapod/ground_contact_solver.py
@@ -85,20 +85,20 @@ def three_ids_of_ground_contacts(legs, tol=1):
         #
         #  cog *  ^ (normal_vector) ----
         #      \  |                  |
-        #       \ |                 height
+        #       \ |               -height
         #        \|                  |
-        #         V p0 (foot_tip) ---V---
+        #         V p0 (foot_tip) ------
         #
         # using p0, p1 or p2 should yield the same result
-        height = dot(n, p0)
+        height = -dot(n, p0)
 
-        # h should be the most negative(the lowest) since
+        # height should be the most largest since
         # the plane defined by this trio is on the ground
         # the other legs ground contact cannot be lower than the ground
         condition_violated = False
         for i in other_trio:
-            _height = dot(n, ground_contacts[i]) + tol
-            if _height < height:
+            _height = -dot(n, ground_contacts[i])
+            if _height > height + tol:
                 # Wrong leg combination, check another
                 condition_violated = True
                 break

--- a/hexapod/models.py
+++ b/hexapod/models.py
@@ -6,7 +6,7 @@ import json
 from pprint import pprint
 from settings import PRINT_MODEL_ON_UPDATE
 from hexapod.linkage import Linkage
-from hexapod.ground_contact_solver import get_legs_on_ground
+from hexapod.ground_contact_solver import compute_orientation_properties
 from hexapod.templates.pose_template import HEXAPOD_POSE
 from hexapod.points import (
     Point,
@@ -105,7 +105,6 @@ class VirtualHexapod:
         "mid",
         "body_rotation_frame",
         "ground_contacts",
-        "n_axis",
         "x_axis",
         "y_axis",
         "z_axis",
@@ -128,13 +127,13 @@ class VirtualHexapod:
 
         # Find new orientation of the body (new normal)
         # distance of cog from ground and which legs are on the ground
-        legs, self.n_axis, height = get_legs_on_ground(self.legs)
+        legs, n_axis, height = compute_orientation_properties(self.legs)
 
-        if self.n_axis is None:
+        if n_axis is None:
             raise Exception("❗Pose Unstable. COG not inside support polygon.")
 
         # Tilt and shift the hexapod based on new normal
-        frame = frame_to_align_vector_a_to_b(self.n_axis, Point(0, 0, 1))
+        frame = frame_to_align_vector_a_to_b(n_axis, Point(0, 0, 1))
         self.rotate_and_shift(frame, height)
         self._update_local_frame(frame)
 

--- a/hexapod/points.py
+++ b/hexapod/points.py
@@ -18,9 +18,11 @@ class Point:
         self.name = name
 
     def get_point_wrt(self, reference_frame, name=None):
-        # given frame_ab which is the pose of frame_b wrt frame_a
-        # given a point as defined wrt to frame_b
-        # return point defined wrt to frame a
+        """
+        Given frame_ab which is the pose of frame_b wrt frame_a
+        and that this point is defined wrt to frame_b
+        Return point defined wrt to frame a
+        """
         p = np.array([self.x, self.y, self.z, 1])
         p = np.matmul(reference_frame, p)
         return Point(p[0], p[1], p[2], name)

--- a/hexapod/points.py
+++ b/hexapod/points.py
@@ -233,8 +233,8 @@ def get_unit_vector(v):
 
 def get_normal_given_three_points(a, b, c):
     """
-     Get the unit normal vector to the
-     plane defined by the points a, b, c
+    Get the unit normal vector to the
+    plane defined by the points a, b, c
     """
     ab = subtract_vectors(b, a)
     ac = subtract_vectors(c, a)

--- a/hexapod/points.py
+++ b/hexapod/points.py
@@ -234,7 +234,7 @@ def get_unit_vector(v):
 def get_normal_given_three_points(a, b, c):
     """
     Get the unit normal vector to the
-    plane defined by the points a, b, c
+    plane defined by the points a, b, c.
     """
     ab = subtract_vectors(b, a)
     ac = subtract_vectors(c, a)

--- a/hexapod/points.py
+++ b/hexapod/points.py
@@ -231,7 +231,11 @@ def get_unit_vector(v):
     return scale(v, length(v))
 
 
-def get_unit_normal(a, b, c):
+def get_normal_given_three_points(a, b, c):
+    """
+     Get the unit normal vector to the
+     plane defined by the points a, b, c
+    """
     ab = subtract_vectors(b, a)
     ac = subtract_vectors(c, a)
     v = cross(ab, ac)


### PR DESCRIPTION
Rename 
1.  hexapod.points.get_unit_normal -> hexapod.points.get_normal_given_three_points
2. hexapod.ground_contact_solver.set_of_two_trios_from_six -> hexapod.ground_contact_solver.set_of_trios_from_six
3. hexapod.ground_contact_solver.get_legs_on_ground -> hexapod.ground_contact_solver.compute_orientation_properties
4. Change definition of height to be positive, for uniformity