### PR TITLE
Put all headers, path names in one place, make variables and functions conform to new convention

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,10 @@
 import os
 import dash
-from style_settings import DARK_CSS_PATH, LIGHT_CSS_PATH, DARKMODE
+from texts import APP_TITLE
+from style_settings import EXTERNAL_STYLESHEETS
 
-external_stylesheets = [DARK_CSS_PATH]
-if not DARKMODE:
-    external_stylesheets = [LIGHT_CSS_PATH]
-
-app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
-app.title = "Mithi's Hexapod Robot Simulator"
+app = dash.Dash(__name__, external_stylesheets=EXTERNAL_STYLESHEETS)
+app.title = APP_TITLE
 server = app.server
 server.secret_key = os.environ.get("secret_key", "secret")
 app.config.suppress_callback_exceptions = True

--- a/index.py
+++ b/index.py
@@ -1,54 +1,58 @@
 import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input, Output
+from texts import (
+    URL_KOFI,
+    URL_REPO,
+    KINEMATICS_PAGE_PATH,
+    IK_PAGE_PATH,
+    PATTERNS_PAGE_PATH,
+    ROOT_PATH,
+)
 from settings import DEBUG_MODE
 from style_settings import GLOBAL_PAGE_STYLE
 from app import app
 from pages import page_inverse, page_kinematics, page_patterns, page_landing
 
-
-URL_KOFI = "https://ko-fi.com/minimithi"
-URL_REPO = "https://github.com/mithi/hexapod-robot-simulator"
 server = app.server
 
-# --------------
-# Navigation bar partials
-# --------------
-
+# ....................
+# Navigation partials
+# ....................
 icon_link_style = {"margin": "0 0 0 0.5em"}
 
 div_header = html.Div(
     [
         html.A(html.H6("👾"), href=URL_REPO, target="_blank", style=icon_link_style),
         html.A(html.H6("☕"), href=URL_KOFI, target="_blank", style=icon_link_style),
-        dcc.Link(html.H6("●"), href="/leg-patterns", style=icon_link_style),
-        dcc.Link(html.H6("●"), href="/inverse-kinematics", style=icon_link_style),
-        dcc.Link(html.H6("●"), href="/kinematics", style=icon_link_style),
-        dcc.Link(html.H6("●"), href="/", style=icon_link_style),
+        dcc.Link(html.H6("●"), href=PATTERNS_PAGE_PATH, style=icon_link_style),
+        dcc.Link(html.H6("●"), href=IK_PAGE_PATH, style=icon_link_style),
+        dcc.Link(html.H6("●"), href=KINEMATICS_PAGE_PATH, style=icon_link_style),
+        dcc.Link(html.H6("●"), href=ROOT_PATH, style=icon_link_style),
     ],
     style={"display": "flex", "flex-direction": "row"},
 )
 
 div_nav = html.Div(
     [
+        html.A("👾 Source Code", href=URL_REPO, target="_blank"),
         html.Br(),
-        html.A("👾 Source Code", href=URL_REPO, target="_blank",),
+        html.A("☕ Buy Mithi coffee", href=URL_KOFI, target="_blank"),
         html.Br(),
-        html.A("☕ Buy Mithi coffee", href=URL_KOFI, target="_blank",),
+        dcc.Link("● Leg Patterns", href=PATTERNS_PAGE_PATH),
         html.Br(),
-        dcc.Link("● Leg Patterns", href="/leg-patterns"),
+        dcc.Link("● Inverse Kinematics", href=IK_PAGE_PATH),
         html.Br(),
-        dcc.Link("● Inverse Kinematics", href="/inverse-kinematics"),
+        dcc.Link("● Kinematics", href=KINEMATICS_PAGE_PATH),
         html.Br(),
-        dcc.Link("● Kinematics", href="/kinematics"),
+        dcc.Link("● Root", href=ROOT_PATH),
         html.Br(),
-        dcc.Link("● Root", href="/"),
-    ]
+    ],
 )
 
-# --------------
-# Layout
-# --------------
+# ....................
+# Page layout
+# ....................
 app.layout = html.Div(
     [
         div_header,
@@ -59,30 +63,31 @@ app.layout = html.Div(
     style=GLOBAL_PAGE_STYLE,
 )
 
-# --------------
+
+# ....................
 # URL redirection
-# --------------
+# ....................
 PAGES = {
-    "/inverse-kinematics": page_inverse.layout,
-    "/kinematics": page_kinematics.layout,
-    "/leg-patterns": page_patterns.layout,
-    "/": page_landing.layout,
+    IK_PAGE_PATH: page_inverse.layout,
+    KINEMATICS_PAGE_PATH: page_kinematics.layout,
+    PATTERNS_PAGE_PATH: page_patterns.layout,
+    ROOT_PATH: page_landing.layout,
 }
 
-# --------------
-# Display page given URL
-# --------------
+# ....................
+# Callback to display page given URL
+# ....................
 @app.callback(Output("page-content", "children"), [Input("url", "pathname")])
 def display_page(pathname):
     try:
         return PAGES[pathname]
     except KeyError:
-        return PAGES["/"]
+        return PAGES[ROOT_PATH]
 
 
-# --------------
+# ....................
 # Run server
-# --------------
+# ....................
 if __name__ == "__main__":
     app.run_server(
         debug=DEBUG_MODE, dev_tools_ui=DEBUG_MODE, dev_tools_props_check=DEBUG_MODE

--- a/pages/page_inverse.py
+++ b/pages/page_inverse.py
@@ -18,7 +18,7 @@ GRAPH_ID = "graph-inverse"
 MESSAGE_SECTION_ID = "message-inverse"
 PARAMETERS_SECTION_ID = "parameters-inverse"
 
-sidebar = shared.make_standard_sidebar(
+sidebar = shared.make_standard_page_sidebar(
     MESSAGE_SECTION_ID, PARAMETERS_SECTION_ID, IK_WIDGETS_SECTION
 )
 

--- a/pages/page_kinematics.py
+++ b/pages/page_kinematics.py
@@ -22,7 +22,7 @@ GRAPH_ID = "graph-kinematics"
 MESSAGE_SECTION_ID = "message-kinematics"
 PARAMETERS_SECTION_ID = "parameters-kinematics"
 
-sidebar = shared.make_standard_sidebar(
+sidebar = shared.make_standard_page_sidebar(
     MESSAGE_SECTION_ID, PARAMETERS_SECTION_ID, KINEMATICS_WIDGETS_SECTION
 )
 

--- a/pages/page_patterns.py
+++ b/pages/page_patterns.py
@@ -15,7 +15,7 @@ GRAPH_ID = "graph-patterns"
 MESSAGE_SECTION_ID = "message-patterns"
 PARAMETERS_SECTION_ID = "parameters-pattens"
 
-sidebar = shared.make_standard_sidebar(
+sidebar = shared.make_standard_page_sidebar(
     MESSAGE_SECTION_ID, PARAMETERS_SECTION_ID, PATTERNS_WIDGETS_SECTION
 )
 

--- a/pages/shared.py
+++ b/pages/shared.py
@@ -20,11 +20,11 @@ DIMENSIONS_SECTION_ID = "hexapod-dimensions-values"
 DIMENSIONS_HIDDEN_SECTION = html.Div(
     id=DIMENSIONS_SECTION_ID, style={"display": "none"}
 )
-DIMS_JSON_SECTION_CALLBACK_INPUT = Input(DIMENSIONS_SECTION_ID, "children")
-DIMS_JSON_SECTION_CALLBACK_OUTPUT = Output(DIMENSIONS_SECTION_ID, "children")
+DIMS_JSON_CALLBACK_INPUT = Input(DIMENSIONS_SECTION_ID, "children")
+DIMS_JSON_CALLBACK_OUTPUT = Output(DIMENSIONS_SECTION_ID, "children")
 
 
-@app.callback(DIMS_JSON_SECTION_CALLBACK_OUTPUT, DIMENSION_CALLBACK_INPUTS)
+@app.callback(DIMS_JSON_CALLBACK_OUTPUT, DIMENSION_CALLBACK_INPUTS)
 def update_hexapod_dimensions_shared(front, side, middle, coxia, femur, tibia):
     dimensions = {
         "front": front or 0,
@@ -63,7 +63,7 @@ def make_standard_page_layout(graph_name, section_controls):
 # ......................
 
 
-def make_standard_sidebar(
+def make_standard_page_sidebar(
     message_section_id, parameters_hidden_section_id, parameter_widgets_section
 ):
     parameters_hidden_section = html.Div(
@@ -85,13 +85,11 @@ def make_standard_sidebar(
 # .....................
 
 
-def make_standard_page_callback_params(
-    graph_name, parameters_section_id, message_section_id
-):
+def make_standard_page_callback_params(graph_id, params_section_id, message_section_id):
 
-    output_message_display = Output(message_section_id, "children")
-    input_parameters_json = Input(parameters_section_id, "children")
-    outputs = [Output(graph_name, "figure"), output_message_display]
-    inputs = [DIMS_JSON_SECTION_CALLBACK_INPUT, input_parameters_json]
-    states = [State(graph_name, "relayoutData"), State(graph_name, "figure")]
+    message_callback_output = Output(message_section_id, "children")
+    params_json_callback_input = Input(params_section_id, "children")
+    outputs = [Output(graph_id, "figure"), message_callback_output]
+    inputs = [DIMS_JSON_CALLBACK_INPUT, params_json_callback_input]
+    states = [State(graph_id, "relayoutData"), State(graph_id, "figure")]
     return outputs, inputs, states

--- a/style_settings.py
+++ b/style_settings.py
@@ -3,6 +3,10 @@ DARKMODE = True
 DARK_CSS_PATH = "https://codepen.io/mithi-the-encoder/pen/BaoBOKa.css"
 LIGHT_CSS_PATH = "https://codepen.io/mithi-the-encoder/pen/eYpObwK.css"
 
+EXTERNAL_STYLESHEETS = [DARK_CSS_PATH]
+if not DARKMODE:
+    EXTERNAL_STYLESHEETS = [LIGHT_CSS_PATH]
+
 
 # ***************************************
 # GLOBAL PAGE STYLE

--- a/texts.py
+++ b/texts.py
@@ -1,0 +1,13 @@
+URL_KOFI = "https://ko-fi.com/minimithi"
+URL_REPO = "https://github.com/mithi/hexapod-robot-simulator"
+KINEMATICS_PAGE_PATH = "/kinematics"
+IK_PAGE_PATH = "/inverse-kinematics"
+PATTERNS_PAGE_PATH = "/leg-patterns"
+ROOT_PATH = "/"
+
+APP_TITLE = "Mithi's Hexapod Robot Simulator"
+
+DIMENSIONS_WIDGETS_HEADER = "robot dimensions".upper()
+PATTERNS_WIDGETS_HEADER = "leg patterns".upper()
+IK_WIDGETS_HEADER = "inverse kinematics".upper()
+KINEMATICS_WIDGETS_HEADER = "kinematics".upper()

--- a/widgets/dimensions_ui.py
+++ b/widgets/dimensions_ui.py
@@ -2,6 +2,7 @@
 import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input
+from texts import DIMENSIONS_WIDGETS_HEADER
 from settings import INPUT_DIMENSIONS_RESOLUTION
 from style_settings import NUMBER_INPUT_STYLE
 from widgets.section_maker import make_section_type3
@@ -26,7 +27,7 @@ def _code(name):
 # COMPONENTS
 # ................................
 
-HEADER = html.Label(dcc.Markdown("**HEXAPOD ROBOT DIMENSIONS**"))
+HEADER = html.Label(dcc.Markdown(f"**{DIMENSIONS_WIDGETS_HEADER}**"))
 WIDGET_NAMES = ["front", "side", "middle", "coxia", "femur", "tibia"]
 DIMENSION_WIDGET_IDS = [f"widget-dimension-{name}" for name in WIDGET_NAMES]
 DIMENSION_CALLBACK_INPUTS = [Input(id, "value") for id in DIMENSION_WIDGET_IDS]

--- a/widgets/ik_ui.py
+++ b/widgets/ik_ui.py
@@ -3,6 +3,7 @@ import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input
 import dash_daq
+from texts import IK_WIDGETS_HEADER
 from style_settings import (
     SLIDER_THEME,
     SLIDER_HANDLE_COLOR,
@@ -72,7 +73,7 @@ def make_rotate_slider(name, slider_label, max_angle=BODY_MAX_ANGLE):
 # COMPONENTS
 # ................................
 
-HEADER = html.Label(dcc.Markdown("**INVERSE KINEMATICS CONTROL**"))
+HEADER = html.Label(dcc.Markdown(f"**{IK_WIDGETS_HEADER}**"))
 IK_WIDGETS_IDS = [
     "widget-start-hip-stance",
     "widget-start-leg-stance",

--- a/widgets/leg_patterns_ui.py
+++ b/widgets/leg_patterns_ui.py
@@ -3,6 +3,7 @@ import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input
 import dash_daq
+from texts import PATTERNS_WIDGETS_HEADER
 from settings import (
     ALPHA_MAX_ANGLE,
     BETA_MAX_ANGLE,
@@ -41,7 +42,7 @@ def make_slider(slider_id, name, max_angle):
 # COMPONENTS
 # ................................
 
-HEADER = html.Label(dcc.Markdown("**LEG POSE CONTROL**"))
+HEADER = html.Label(dcc.Markdown(f"**{PATTERNS_WIDGETS_HEADER}**"))
 WIDGET_NAMES = ["alpha", "beta", "gamma"]
 PATTERNS_WIDGET_IDS = [f"widget-{name}" for name in WIDGET_NAMES]
 PATTERNS_CALLBACK_INPUTS = [Input(i, "value") for i in PATTERNS_WIDGET_IDS]

--- a/widgets/pose_control/components.py
+++ b/widgets/pose_control/components.py
@@ -1,6 +1,7 @@
 import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input
+from texts import KINEMATICS_WIDGETS_HEADER
 from hexapod.const import NAMES_LEG, NAMES_JOINT
 
 
@@ -21,5 +22,5 @@ def make_all_joint_callback_inputs():
 # COMPONENTS
 # ................................
 
-HEADER = html.Label(dcc.Markdown("**KINEMATICS CONTROL**"))
+HEADER = html.Label(dcc.Markdown(f"**{KINEMATICS_WIDGETS_HEADER}**"))
 KINEMATICS_CALLBACK_INPUTS = make_all_joint_callback_inputs()


### PR DESCRIPTION
- Rename function to make_standard_page_sidebar
- Put all headers, titles, page urls and page paths on one place (text.py)
- make variables in standard_page_callback_params conform to new naming convention